### PR TITLE
mixins.init: Don't import tornado mixin

### DIFF
--- a/test_helpers/mixins/__init__.py
+++ b/test_helpers/mixins/__init__.py
@@ -15,6 +15,5 @@ as possible.  Each mixin class should ideally only inherit from
 """
 
 from .patch_mixin import PatchMixin
-from .tornado import TornadoMixin
 
-__all__ = ('PatchMixin', 'TornadoMixin')
+__all__ = ('PatchMixin')


### PR DESCRIPTION
This mixin requires the `tornado` package, which is an optional
dependency, so we can't import it in the `__init__.py`.
