### PR TITLE
Tornado patch head options

### DIFF
--- a/test_helpers/mixins/tornado.py
+++ b/test_helpers/mixins/tornado.py
@@ -139,6 +139,16 @@ class TornadoMixin(object):
         return cls.request('PATCH', path, body=body, **kwargs)
 
     @classmethod
+    def options(cls, path, **kwargs):
+        """Issue a ``OPTIONS`` request."""
+        return cls.request('OPTIONS', path, **kwargs)
+
+    @classmethod
+    def head(cls, path, **kwargs):
+        """Issue a ``HEAD`` request."""
+        return cls.request('HEAD', path, **kwargs)
+
+    @classmethod
     def request(cls, method, path, **kwargs):
         """Issue a request to the application.
 

--- a/tests/integration/test_tornado_mixins.py
+++ b/tests/integration/test_tornado_mixins.py
@@ -133,10 +133,23 @@ class WhenTornadoMixinRequestsOptions(_TornadoMixinTestCase):
 
     @classmethod
     def execute(cls):
-        cls.test_instance.request('OPTIONS', '/')
+        cls.test_instance.options('/')
 
     def should_request_options__from_request_handler(self):
         self.assertEqual(self.request.method, 'OPTIONS')
+
+    def should_request_appropriate_resource(self):
+        self.assertEqual(self.request.path, '/')
+
+
+class WhenTornadoMixinRequestsHead(_TornadoMixinTestCase):
+
+    @classmethod
+    def execute(cls):
+        cls.test_instance.head('/')
+
+    def should_request_options__from_request_handler(self):
+        self.assertEqual(self.request.method, 'HEAD')
 
     def should_request_appropriate_resource(self):
         self.assertEqual(self.request.path, '/')


### PR DESCRIPTION
This PR adds explicit patch, options, and head methods to the TornadoMixin to facilitate testing of those HTTP methods. Corresponding integration tests were also added.

To test:
1) clone the repo
2) cd ./test-helpers
3) make test
