### PR TITLE
travis: Use new build infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ services:
   - rabbitmq
 after_success:
   - coveralls
+sudo: false
 deploy:
   provider: pypi
   distributions: "sdist bdist_wheel"


### PR DESCRIPTION
Set `sudo` to `false` in our `travis.yml`, which has the effect of our
builds running on the new Travis.ci container infrastructure, touted to
be much faster than the current process.

http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/
