### PR TITLE
Mongodb helper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ install:
   - pip install -r requirements.pip
 services:
   - rabbitmq
+  - mongodb
 script: nosetests
 after_success:
   - coveralls

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@ Release History
 * Next Release
 
   - ``test_helpers.postgres`` module added
+  - ``test_helpers.mongo`` module added
 
 * 1.5.2
 

--- a/README.rst
+++ b/README.rst
@@ -56,6 +56,19 @@ you must either:
 1. install Tornado as a dependency *OR*
 2. include a dependency on ``test_helpers[tornado]`` in your pip requirements
 
+Dependent Data Service Helpers
+------------------------------
+
+The Test Helpers library includes classes that facilitate initializing and
+cleaning up dependent data service resources. Provided with connection
+configuration to existing service instances, each class can generate name-spaced
+workspaces and tear down any created workspaces at the end of each test run.
+
+Currently included:
+
+- MongoDB
+- PostgreSQL
+- RabbitMQ
 
 Supported Python Versions
 --------------------------
@@ -91,4 +104,3 @@ Dan Tracy, `John Brodie`_ at `AWeber Communications`_
 .. _Arrange-Act-Assert: http://c2.com/cgi/wiki?ArrangeActAssert
 .. _John Brodie: http://brodie.me
 .. _AWeber Communications: http://www.aweber.com
-

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,3 +7,4 @@ mock==1.0.1
 nose==1.3.0
 tornado>=3.1
 psycopg2>=2.5,<3.0
+pymongo>=2.7,<2.8

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -42,6 +42,7 @@ Documentation
 
    bases
    mixins
+   mongo
    postgres
    rabbit
    utils

--- a/docs/mongo.rst
+++ b/docs/mongo.rst
@@ -1,0 +1,5 @@
+MongoDB Helpers
+================
+
+.. autoclass:: test_helpers.mongo.TemporaryDatabase
+   :members:

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
         'tornado': ['tornado>=3.1'],
         'rabbit': ['requests>=2.3'],
         'postgres': ['psycopg2>=2.5,<3.0'],
+        'mongo': ['pymongo>=2.7,<2.8']
     },
     classifiers=[
         'Development Status :: 5 - Production/Stable',

--- a/test_helpers/mongo.py
+++ b/test_helpers/mongo.py
@@ -80,3 +80,16 @@ class TemporaryDatabase(object):
         mongodb.drop_database(self.database_name)
         _temporary_databases.remove(self)
         self.database_name = None
+
+    def set_environment(self):
+        """
+        Export MongoDB environment variables for the database.
+
+        This exports the :envvar:`MONGOHOST`, :envvar:`MONGOPORT`, and
+        :envvar:`MONGODATABASE` environment variables
+
+        """
+        os.environ['MONGOHOST'] = self.host
+        os.environ['MONGOPORT'] = str(self.port)
+        if self.database_name is not None:
+            os.environ['MONGODATABASE'] = self.database_name

--- a/test_helpers/mongo.py
+++ b/test_helpers/mongo.py
@@ -23,6 +23,32 @@ atexit.register(_remove_databases)
 
 
 class TemporaryDatabase(object):
+    """
+    Creates a temporary MongoDB database that is destroyed automatically.
+
+    :keyword str host: Database to connect to. This defaults to
+        :envvar: ``MONGOHOST`` or ``localhost`` if omitted.
+    :keyword int port: Port number that the database is listening on. This
+        defaults to :envvar: ``MONGOPORT` or ``27017`` if omitted.
+
+    Instances of this class will create a bare MongoDB database with a single
+    collection named ``test_helpers`` containing a single document with a
+    create date for tracking purposes. When the test process exits all
+    databases created will be destroyed automatically. Under the hood it uses
+    ``pymongo`` and registers a single cleanup function with
+    :func`atexit.register`.
+
+    **Usage Example**
+
+    .. code-block:: python
+
+       from test_helpers import mongo
+
+       _testing_db = mongo.TemporaryDatabase()
+
+       def setup_module():
+           _testing_db.create()
+    """
 
     def __init__(self, **kwargs):
         super(TemporaryDatabase, self).__init__()
@@ -32,6 +58,8 @@ class TemporaryDatabase(object):
         self.database_name = None
 
     def create(self):
+        """Create the temporary database if it does not exist."""
+
         if self.database_name is not None:
             return
         database_name = 'test{0}'.format(uuid.uuid4().hex)
@@ -45,6 +73,7 @@ class TemporaryDatabase(object):
         _temporary_databases.append(self)
 
     def drop(self):
+        """Drop the temporary database if it was created."""
         if self.database_name is None:
             return
         mongodb = MongoClient(self.host, self.port)

--- a/tests/integration/test_mongo.py
+++ b/tests/integration/test_mongo.py
@@ -56,11 +56,11 @@ class WhenCreatingTemporaryDatabaseAndExportingEnv(
     def execute(cls):
         cls.database.set_environment()
 
-    def should_export_pghost(self):
+    def should_export_mongohost(self):
         self.assertEqual(os.environ['MONGOHOST'], self.database.host)
 
-    def should_export_pgport(self):
+    def should_export_mongoport(self):
         self.assertEqual(os.environ['MONGOPORT'], str(self.database.port))
 
-    def should_export_pgdatabase(self):
+    def should_export_mongodatabase(self):
         self.assertEqual(os.environ['MONGODATABASE'], self.database.database_name)

--- a/tests/integration/test_mongo.py
+++ b/tests/integration/test_mongo.py
@@ -1,0 +1,38 @@
+from __future__ import absolute_import
+
+from pymongo import MongoClient
+
+from test_helpers import bases, mixins, mongo
+
+
+class WhenCreatingTemporaryDatabase(bases.BaseTest):
+
+    @classmethod
+    def configure(cls):
+        super(WhenCreatingTemporaryDatabase, cls).configure()
+        cls.database = mongo.TemporaryDatabase(host='localhost', port=27017)
+
+    @classmethod
+    def execute(cls):
+        cls.database.create()
+
+    def should_create_database(self):
+        mongodb = MongoClient(host='localhost', port=27017)
+        self.assertIn(self.database.database_name, mongodb.database_names())
+
+
+class WhenDroppingTemporaryDatabase(bases.BaseTest):
+
+    @classmethod
+    def configure(cls):
+        super(WhenDroppingTemporaryDatabase, cls).configure()
+        cls.database = mongo.TemporaryDatabase(host='localhost', port=27017)
+        cls.database.create()
+
+    @classmethod
+    def execute(cls):
+        cls.database.drop()
+
+    def should_drop_database(self):
+        mongodb = MongoClient(host='localhost', port=27017)
+        self.assertNotIn(self.database.database_name, mongodb.database_names())

--- a/tests/unit/test_mongo.py
+++ b/tests/unit/test_mongo.py
@@ -1,0 +1,51 @@
+import pymongo
+
+from test_helpers import bases, compat, mixins, mongo
+
+
+class WhenRemovingDatabases(mixins.PatchMixin, bases.BaseTest):
+    patch_prefix = 'test_helpers.mongo'
+
+    @classmethod
+    def configure(cls):
+        super(WhenRemovingDatabases, cls).configure()
+        cls.db_object = compat.mock.Mock()
+        cls.temp_db_list = cls.create_patch(
+            '_temporary_databases', new_callable=list)
+        cls.temp_db_list.append(cls.db_object)
+
+    @classmethod
+    def execute(cls):
+        mongo._remove_databases()
+
+    def should_drop_databases(self):
+        self.db_object.drop.assert_called_once_with()
+
+    def should_clear_variable(self):
+        self.assertEqual(mongo._temporary_databases, [])
+
+
+class WhenDatabaseRemovalFails(mixins.PatchMixin, bases.BaseTest):
+    patch_prefix = 'test_helpers.mongo'
+
+    @classmethod
+    def configure(cls):
+        super(WhenDatabaseRemovalFails, cls).configure()
+        cls.db_object = compat.mock.Mock()
+        cls.db_object.drop.side_effect = pymongo.errors.InvalidOperation
+
+        cls.temp_db_list = cls.create_patch(
+            '_temporary_databases', new_callable=list)
+        cls.temp_db_list.append(cls.db_object)
+        cls.logger = cls.create_patch('_logger')
+
+    @classmethod
+    def execute(cls):
+        mongo._remove_databases()
+
+    def should_log_failure(self):
+        self.logger.exception.assert_called_once_with(
+            compat.mock.ANY, self.db_object.database_name)
+
+    def should_still_clear_list(self):
+        self.assertEqual(mongo._temporary_databases, [])


### PR DESCRIPTION
This PR adds a helper that allows for creation of testing MongoDB databases and tears them down after test runs. The new Mongo class attempts to follow patterns set by the Postgres helper.

Tests pass and Pep8 has no complaints for me. I'm not sure what changes are needed to work with Travis and I'm not a Python expert so any feedback is greatly appreciated.