### PR TITLE
Release 1.5.3

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,19 +1,23 @@
 Release History
 ---------------
 
-* Next Release
+* `1.5.3`_
 
   - ``test_helpers.postgres`` module added
   - ``test_helpers.mongo`` module added
 
-* 1.5.2
+* `1.5.2`_
 
   - ``test_helpers.rabbit`` module added
 
-* 1.5.1
+* `1.5.1`_
 
   - Allow use of `mixins` module without requiring the ``tornado`` package
 
 * 1.5.0
 
   - Initial public release.
+
+.. _1.5.3: https://github.com/aweber/test-helpers/compare/1.5.2...1.5.3
+.. _1.5.2: https://github.com/aweber/test-helpers/compare/1.5.1...1.5.2
+.. _1.5.1: https://github.com/aweber/test-helpers/compare/1.5.0...1.5.1

--- a/test_helpers/__init__.py
+++ b/test_helpers/__init__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
-version_info = (1, 5, 2)
+version_info = (1, 5, 3)
 __version__ = '.'.join(str(c) for c in version_info[:3])


### PR DESCRIPTION
This PR bumps the version information and updates the CHANGELOG.  After this is merged we need to explicitly tag for travis to upload the release.

**Important Note**: after the tag is in there, make sure that the travis build actually uploads the release.  A good example is [Build 62] which succeeded.  However, the upload task is buried in the [2.7 variant] which completely failed to upload :confused: 

````
Fetching: dpl-1.7.8.gem (100%)
Successfully installed dpl-1.7.8
1 gem installed
0.00s/home/travis/build.sh: eval: line 41: unexpected EOF while looking for matching ``'
/home/travis/build.sh: eval: line 42: syntax error: unexpected end of file
````

If this happens again, we have to manually upload to PyPI and should consider doing the `setup.py sdist upload` in our script though I'm not sure how the user+password will work out there.

[Build 62]: https://travis-ci.org/aweber/test-helpers/builds/44363269
[2.7 variant]: https://travis-ci.org/aweber/test-helpers/jobs/44363271