### PR TITLE
Do not strictly require execute to be defined

### DIFF
--- a/test_helpers/bases.py
+++ b/test_helpers/bases.py
@@ -67,4 +67,4 @@ class BaseTest(unittest.TestCase):
     @classmethod
     def execute(cls):
         """Override to execute your test action."""
-        raise NotImplementedError('The execute action was not defined!')
+        pass


### PR DESCRIPTION
This PR relaxes the strict requirement for the `execute` method to be overridden.  Different styles of testing call for defining an empty `execute` method which is kind of clunky.