### PR TITLE
Allow alternate RabbitMQ ports to be specified

### DIFF
--- a/tests/integration/test_rabbit.py
+++ b/tests/integration/test_rabbit.py
@@ -34,7 +34,8 @@ class _BaseRabbitTestCase(mixins.EnvironmentMixin, bases.BaseTest):
     def configure(cls):
         super(_BaseRabbitTestCase, cls).configure()
         cls.fixture = rabbit.RabbitMqFixture(
-            host=RABBIT_HOST, user='guest', password='guest')
+            host=RABBIT_HOST, user='guest', password='guest',
+            port=5672, mgmt_port=15672)
         cls.unset_environment_variable('AMQP')
 
     @staticmethod


### PR DESCRIPTION
Allow alternate RabbitMQ service and management ports to be specified so that
testing can be done with Dockerized RabbitMQ nodes.
